### PR TITLE
Enforce ja locale

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,19 +5,7 @@ class ApplicationController < ActionController::Base
   private
 
   def set_locale
-    case
-    when params[:hl] 
-      if I18n.available_locales.include?(params[:hl].to_sym)
-        session[:hl] = params[:hl].to_sym
-      else
-        session.delete(:hl)
-      end
-    when !session[:hl] && request.headers['HTTP_CLOUDFRONT_VIEWER_COUNTRY']&.downcase == 'jp'
-      session[:hl] = :ja
-    end
-    if session[:hl]
-      I18n.locale = session[:hl]
-    end
+    session[:hl] = :ja
   end
 
   helper_method def current_staff

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -63,17 +63,7 @@ class TicketsController < ApplicationController
   end
 
   private def set_locale
-    if params[:hl] 
-      if I18n.available_locales.include?(params[:hl].to_sym)
-        session[:hl] = params[:hl].to_sym
-      else
-        session.delete(:hl)
-      end
-    end
-
-    if session[:hl]
-      I18n.locale = session[:hl]
-    end
+    session[:hl] = :ja
   end
 
   private def ticket_params


### PR DESCRIPTION
東京Ruby会議12では en ロケールを設定していないので、Accept-Language (`I18n.available_locales`) などに依らず ja ロケールを強制します。
（現状では en, en-US が上位にある環境では en のテンプレートをレンダリングできずエラーになる）